### PR TITLE
[feat] API 응답 통일 코드 작성 및 domain 작성

### DIFF
--- a/src/main/java/qp/official/qp/apiPayload/ApiResponse.java
+++ b/src/main/java/qp/official/qp/apiPayload/ApiResponse.java
@@ -1,0 +1,38 @@
+package qp.official.qp.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import qp.official.qp.apiPayload.code.BaseCode;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+
+    public static <T> ApiResponse<T> onSuccess(String code, String message, T result){
+        return new ApiResponse<>(true, code, message, result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/qp/official/qp/apiPayload/code/BaseCode.java
+++ b/src/main/java/qp/official/qp/apiPayload/code/BaseCode.java
@@ -1,0 +1,8 @@
+package qp.official.qp.apiPayload.code;
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/qp/official/qp/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/qp/official/qp/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package qp.official.qp.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/qp/official/qp/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/qp/official/qp/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,18 @@
+package qp.official.qp.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/qp/official/qp/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/qp/official/qp/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,18 @@
+package qp.official.qp.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/qp/official/qp/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/qp/official/qp/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,62 @@
+package qp.official.qp.apiPayload.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import qp.official.qp.apiPayload.code.BaseErrorCode;
+import qp.official.qp.apiPayload.code.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 회원 관려 에러 1000
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_1001", "사용자가 없습니다."),
+    NAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER_1002", "이름입력은 필수 입니다."),
+
+    // 질문 관려 에러 2000
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_2001", "찾고있는 질문글이 없습니다."),
+
+    // 답변 관련 에러 3000
+    ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "ANSWER_3001", "찾고있는 답변이 없습니다."),
+
+    // 신고 관련 에러 4000
+
+    // 이미지 관련 에러 5000
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_5001", "찾고있는 이미지가 없습니다."),
+
+    // 해시태그 관련 에러 6000
+    HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "HASHTAG_6001", "찾고있는 해시태그가 없습니다.");
+
+    // 답변 좋아요 관련 에러 7000
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/qp/official/qp/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/qp/official/qp/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,57 @@
+package qp.official.qp.apiPayload.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import qp.official.qp.apiPayload.code.BaseCode;
+import qp.official.qp.apiPayload.code.ReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 유저 관련 응답
+    User_OK(HttpStatus.OK, "USER_1000", "성공입니다."),
+
+    // 질문 관련 응답
+    Question_OK(HttpStatus.OK, "QUESTION_2000", "성공입니다."),
+
+    // 답변 관련 응답
+    Answer_OK(HttpStatus.OK, "ANSWER_3000", "성공입니다."),
+
+    // 신고 관련 응답
+    Report_OK(HttpStatus.OK, "REPORT_4000", "성공입니다."),
+
+    // 이미지 관련 응답
+    Image_OK(HttpStatus.OK, "IMAGE_5000", "성공입니다."),
+
+    // 해시태그 관련 응답
+    Hashtag_OK(HttpStatus.OK, "HASHTAG_6000", "성공입니다."),
+
+    // 답변 좋아요 관련 응답
+    AnswerLike_OK(HttpStatus.OK, "ANSWERLIKE_7000", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/qp/official/qp/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/qp/official/qp/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,120 @@
+package qp.official.qp.apiPayload.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import qp.official.qp.apiPayload.ApiResponse;
+import qp.official.qp.apiPayload.code.ErrorReasonDTO;
+import qp.official.qp.apiPayload.code.status.ErrorStatus;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+
+    //@org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatus status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/qp/official/qp/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/qp/official/qp/apiPayload/exception/ExceptionAdvice.java
@@ -15,8 +15,8 @@ import qp.official.qp.apiPayload.ApiResponse;
 import qp.official.qp.apiPayload.code.ErrorReasonDTO;
 import qp.official.qp.apiPayload.code.status.ErrorStatus;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.ConstraintViolationException;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/qp/official/qp/apiPayload/exception/GeneralException.java
+++ b/src/main/java/qp/official/qp/apiPayload/exception/GeneralException.java
@@ -1,0 +1,21 @@
+package qp.official.qp.apiPayload.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import qp.official.qp.apiPayload.code.BaseErrorCode;
+import qp.official.qp.apiPayload.code.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/qp/official/qp/converter/QuestionConverter.java
+++ b/src/main/java/qp/official/qp/converter/QuestionConverter.java
@@ -1,0 +1,11 @@
+package qp.official.qp.converter;
+
+import qp.official.qp.web.dto.QuestionResponseDTO;
+
+public class QuestionConverter {
+    public static QuestionResponseDTO.QuestionTestDTO toQuestionTestDTO(){
+        return QuestionResponseDTO.QuestionTestDTO.builder()
+                .testString("This is Test!")
+                .build();
+    }
+}

--- a/src/main/java/qp/official/qp/domain/Answer.java
+++ b/src/main/java/qp/official/qp/domain/Answer.java
@@ -1,0 +1,47 @@
+package qp.official.qp.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import qp.official.qp.domain.common.BaseEntity;
+import qp.official.qp.domain.enums.Category;
+import qp.official.qp.domain.mapping.AnswerLikes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Answer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long answerId;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private Category category;
+
+    private Boolean is_updated;
+
+    private Long answerGroup;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @OneToMany(mappedBy = "answer", cascade = CascadeType.ALL)
+    private List<AnswerLikes> answerLikesList = new ArrayList<>();
+}

--- a/src/main/java/qp/official/qp/domain/Answer.java
+++ b/src/main/java/qp/official/qp/domain/Answer.java
@@ -1,6 +1,6 @@
 package qp.official.qp.domain;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import lombok.*;
 import qp.official.qp.domain.common.BaseEntity;
 import qp.official.qp.domain.enums.Category;

--- a/src/main/java/qp/official/qp/domain/Hashtag.java
+++ b/src/main/java/qp/official/qp/domain/Hashtag.java
@@ -1,6 +1,6 @@
 package qp.official.qp.domain;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import lombok.*;
 import qp.official.qp.domain.common.BaseEntity;
 import qp.official.qp.domain.mapping.QuestionHashTag;

--- a/src/main/java/qp/official/qp/domain/Hashtag.java
+++ b/src/main/java/qp/official/qp/domain/Hashtag.java
@@ -1,0 +1,27 @@
+package qp.official.qp.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import qp.official.qp.domain.common.BaseEntity;
+import qp.official.qp.domain.mapping.QuestionHashTag;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Hashtag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long hashtagId;
+
+    @Column(nullable = false, length = 20)
+    private String hashtag;
+
+    @OneToMany(mappedBy = "hashtag", cascade = CascadeType.ALL)
+    private List<QuestionHashTag> questionHashTagList = new ArrayList<>();
+}

--- a/src/main/java/qp/official/qp/domain/Question.java
+++ b/src/main/java/qp/official/qp/domain/Question.java
@@ -1,6 +1,6 @@
 package qp.official.qp.domain;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import lombok.*;
 import qp.official.qp.domain.common.BaseEntity;
 import qp.official.qp.domain.mapping.QuestionHashTag;

--- a/src/main/java/qp/official/qp/domain/Question.java
+++ b/src/main/java/qp/official/qp/domain/Question.java
@@ -1,0 +1,36 @@
+package qp.official.qp.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import qp.official.qp.domain.common.BaseEntity;
+import qp.official.qp.domain.mapping.QuestionHashTag;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Question extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long questionId;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private Long hit;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+    private List<QuestionHashTag> questionHashTagList = new ArrayList<>();
+}

--- a/src/main/java/qp/official/qp/domain/User.java
+++ b/src/main/java/qp/official/qp/domain/User.java
@@ -1,6 +1,6 @@
 package qp.official.qp.domain;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import lombok.*;
 import qp.official.qp.domain.common.BaseEntity;
 import qp.official.qp.domain.enums.Gender;

--- a/src/main/java/qp/official/qp/domain/User.java
+++ b/src/main/java/qp/official/qp/domain/User.java
@@ -1,0 +1,62 @@
+package qp.official.qp.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import qp.official.qp.domain.common.BaseEntity;
+import qp.official.qp.domain.enums.Gender;
+import qp.official.qp.domain.enums.UserStatus;
+import qp.official.qp.domain.enums.Role;
+import qp.official.qp.domain.mapping.AnswerLikes;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Column(nullable = false, length = 20)
+    private String nickname;
+
+    @Column(columnDefinition = "TEXT")
+    private String profileImage;
+
+    @Column(nullable = false, length = 40)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private Gender gender;
+
+    private Long point;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(15) DEFAULT 'ACTIVE'")
+    private UserStatus status;
+
+    private LocalDateTime lastLogin;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Question> questionList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Answer> answerList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<AnswerLikes> answerLikesList = new ArrayList<>();
+}

--- a/src/main/java/qp/official/qp/domain/common/BaseEntity.java
+++ b/src/main/java/qp/official/qp/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package qp.official.qp.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/qp/official/qp/domain/common/BaseEntity.java
+++ b/src/main/java/qp/official/qp/domain/common/BaseEntity.java
@@ -1,7 +1,7 @@
 package qp.official.qp.domain.common;
 
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;

--- a/src/main/java/qp/official/qp/domain/enums/Category.java
+++ b/src/main/java/qp/official/qp/domain/enums/Category.java
@@ -1,0 +1,5 @@
+package qp.official.qp.domain.enums;
+
+public enum Category {
+    PARENT, CHILD
+}

--- a/src/main/java/qp/official/qp/domain/enums/Gender.java
+++ b/src/main/java/qp/official/qp/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package qp.official.qp.domain.enums;
+
+public enum Gender {
+    MALE, FEMALE, DEFAULT
+}

--- a/src/main/java/qp/official/qp/domain/enums/Role.java
+++ b/src/main/java/qp/official/qp/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package qp.official.qp.domain.enums;
+
+public enum Role {
+    USER, ADJIN, CHILD, EXPERT
+}

--- a/src/main/java/qp/official/qp/domain/enums/UserStatus.java
+++ b/src/main/java/qp/official/qp/domain/enums/UserStatus.java
@@ -1,0 +1,5 @@
+package qp.official.qp.domain.enums;
+
+public enum UserStatus {
+    ACTIVATE, DELETED
+}

--- a/src/main/java/qp/official/qp/domain/mapping/AnswerLikes.java
+++ b/src/main/java/qp/official/qp/domain/mapping/AnswerLikes.java
@@ -1,6 +1,6 @@
 package qp.official.qp.domain.mapping;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import lombok.*;
 import qp.official.qp.domain.Answer;
 import qp.official.qp.domain.User;

--- a/src/main/java/qp/official/qp/domain/mapping/AnswerLikes.java
+++ b/src/main/java/qp/official/qp/domain/mapping/AnswerLikes.java
@@ -1,0 +1,27 @@
+package qp.official.qp.domain.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import qp.official.qp.domain.Answer;
+import qp.official.qp.domain.User;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AnswerLikes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long AnswerLikeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id")
+    private Answer answer;
+
+}

--- a/src/main/java/qp/official/qp/domain/mapping/AnswerReport.java
+++ b/src/main/java/qp/official/qp/domain/mapping/AnswerReport.java
@@ -1,0 +1,31 @@
+package qp.official.qp.domain.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import qp.official.qp.domain.Answer;
+import qp.official.qp.domain.User;
+import qp.official.qp.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AnswerReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long AnswerReportId;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id")
+    private Answer answer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+}

--- a/src/main/java/qp/official/qp/domain/mapping/AnswerReport.java
+++ b/src/main/java/qp/official/qp/domain/mapping/AnswerReport.java
@@ -1,6 +1,6 @@
 package qp.official.qp.domain.mapping;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import lombok.*;
 import qp.official.qp.domain.Answer;
 import qp.official.qp.domain.User;

--- a/src/main/java/qp/official/qp/domain/mapping/QuestionHashTag.java
+++ b/src/main/java/qp/official/qp/domain/mapping/QuestionHashTag.java
@@ -1,0 +1,27 @@
+package qp.official.qp.domain.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import qp.official.qp.domain.Hashtag;
+import qp.official.qp.domain.Question;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class QuestionHashTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long QuestionHashtagId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag;
+
+}

--- a/src/main/java/qp/official/qp/domain/mapping/QuestionHashTag.java
+++ b/src/main/java/qp/official/qp/domain/mapping/QuestionHashTag.java
@@ -1,6 +1,6 @@
 package qp.official.qp.domain.mapping;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import lombok.*;
 import qp.official.qp.domain.Hashtag;
 import qp.official.qp.domain.Question;

--- a/src/main/java/qp/official/qp/domain/mapping/QuestionReport.java
+++ b/src/main/java/qp/official/qp/domain/mapping/QuestionReport.java
@@ -1,6 +1,6 @@
 package qp.official.qp.domain.mapping;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import lombok.*;
 import qp.official.qp.domain.Question;
 import qp.official.qp.domain.User;

--- a/src/main/java/qp/official/qp/domain/mapping/QuestionReport.java
+++ b/src/main/java/qp/official/qp/domain/mapping/QuestionReport.java
@@ -1,0 +1,31 @@
+package qp.official.qp.domain.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import qp.official.qp.domain.Question;
+import qp.official.qp.domain.User;
+import qp.official.qp.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class QuestionReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long AnswerReportId;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+}

--- a/src/main/java/qp/official/qp/domain/mapping/UserQuestionAlarm.java
+++ b/src/main/java/qp/official/qp/domain/mapping/UserQuestionAlarm.java
@@ -1,6 +1,6 @@
 package qp.official.qp.domain.mapping;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import lombok.*;
 import qp.official.qp.domain.Question;
 import qp.official.qp.domain.User;

--- a/src/main/java/qp/official/qp/domain/mapping/UserQuestionAlarm.java
+++ b/src/main/java/qp/official/qp/domain/mapping/UserQuestionAlarm.java
@@ -1,0 +1,29 @@
+package qp.official.qp.domain.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import qp.official.qp.domain.Question;
+import qp.official.qp.domain.User;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserQuestionAlarm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long AlarmId;
+
+    private Boolean IsAlarmed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+}

--- a/src/main/java/qp/official/qp/web/controller/QuestionRestController.java
+++ b/src/main/java/qp/official/qp/web/controller/QuestionRestController.java
@@ -1,0 +1,23 @@
+package qp.official.qp.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import qp.official.qp.apiPayload.ApiResponse;
+import qp.official.qp.apiPayload.code.status.SuccessStatus;
+import qp.official.qp.converter.QuestionConverter;
+import qp.official.qp.web.dto.QuestionResponseDTO;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/questions")
+public class QuestionRestController {
+
+    @PostMapping("/test")
+    public ApiResponse<QuestionResponseDTO.QuestionTestDTO> testAPI(){
+        return ApiResponse.onSuccess(SuccessStatus.Question_OK.getCode(), SuccessStatus.Question_OK.getMessage(), QuestionConverter.toQuestionTestDTO());
+    }
+}

--- a/src/main/java/qp/official/qp/web/dto/AnswerLikeRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/AnswerLikeRequestDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class AnswerLikeRequestDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/AnswerLikeResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/AnswerLikeResponseDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class AnswerLikeResponseDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/AnswerRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/AnswerRequestDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class AnswerRequestDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/AnswerResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/AnswerResponseDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class AnswerResponseDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/HashtagRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/HashtagRequestDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class HashtagRequestDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/HashtagResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/HashtagResponseDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class HashtagResponseDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/ImageRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/ImageRequestDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class ImageRequestDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/ImageResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/ImageResponseDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class ImageResponseDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/QuestionRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/QuestionRequestDTO.java
@@ -1,6 +1,6 @@
 package qp.official.qp.web.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 
 public class QuestionRequestDTO {

--- a/src/main/java/qp/official/qp/web/dto/QuestionRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/QuestionRequestDTO.java
@@ -1,0 +1,17 @@
+package qp.official.qp.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class QuestionRequestDTO {
+
+//    @Getter
+//    public static class CreateDTO{
+//        @NotBlank
+//        int user_id;
+//        @NotBlank
+//        String title;
+//        @NotBlank
+//        String content;
+//    }
+}

--- a/src/main/java/qp/official/qp/web/dto/QuestionResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/QuestionResponseDTO.java
@@ -1,0 +1,17 @@
+package qp.official.qp.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class QuestionResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionTestDTO{
+        String testString;
+    }
+}

--- a/src/main/java/qp/official/qp/web/dto/ReportRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/ReportRequestDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class ReportRequestDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/ReportResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/ReportResponseDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class ReportResponseDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/UserRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserRequestDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class UserRequestDTO {
+}

--- a/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
@@ -1,0 +1,4 @@
+package qp.official.qp.web.dto;
+
+public class UserResponseDTO {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/QP_DB
-    username: Luffy_QP
+    url: jdbc:mysql://localhost:3306/qp
+    username: root
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/qp
-    username: root
+    url: jdbc:mysql://localhost:3306/QP_DB
+    username: Luffy_QP
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql:
@@ -15,5 +15,5 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: update
+          auto: create
         default_batch_fetch_size: 1000


### PR DESCRIPTION
## PR type
- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Chore

## 💻 작업사항

- 작업사항 1
API 응답 통일 코드 작성하고 QuestionRestController에서 2000번코드로 성공 응답 받는 것 테스트해보았습니다.
실패 응답은 workbook내용 복사만 해두었습니다.
- 작업사항 2
converter만들기 전에 domain부터 만들어야 할 것 같아 erd에 대한 domain작성하였습니다. datagrip에 mysql연결하여 table생성되는 것까지 확인하였습니다.

## 💡 작성한 이슈 외에 작업한 사항

- 작업사항 1
자바 버전 11로 변경하였고 브랜치이름은 feature/5로 변경하였습니다.

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
