### PR TITLE
[fix] 질문 신고, 해시태그, 이미지, 유저 입력 값 비어 있는 경우 500대 에러 발생 오류 수정

### DIFF
--- a/src/main/java/qp/official/qp/web/dto/HashtagRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/HashtagRequestDTO.java
@@ -1,11 +1,13 @@
 package qp.official.qp.web.dto;
 
+import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 
 public class HashtagRequestDTO {
 
     @Getter
     public static class HashtagDTO{
+        @NotBlank
         String hashtag;
     }
 

--- a/src/main/java/qp/official/qp/web/dto/ImageRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/ImageRequestDTO.java
@@ -1,11 +1,14 @@
 package qp.official.qp.web.dto;
 
+import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 
 public class ImageRequestDTO {
 
     @Getter
     public static class ImageDTO{
+
+        @NotBlank
         String url;
     }
 }

--- a/src/main/java/qp/official/qp/web/dto/QuestionReportRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/QuestionReportRequestDTO.java
@@ -1,5 +1,6 @@
 package qp.official.qp.web.dto;
 
+import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 import qp.official.qp.validation.annotation.ExistUser;
 
@@ -9,6 +10,7 @@ public class QuestionReportRequestDTO {
     public static class QuestionReportDTO{
         @ExistUser
         Long userId;
+        @NotBlank
         String content;
     }
 

--- a/src/main/java/qp/official/qp/web/dto/QuestionRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/QuestionRequestDTO.java
@@ -15,11 +15,11 @@ public class QuestionRequestDTO {
     public static class CreateDTO {
         @ExistUser
         Long userId;
-        @NotBlank
+
         @Size(min = 1, max = 50)
         @NotBlank
         String title;
-        @NotBlank
+
         @Size(min = 1, max = 1500)
         @NotBlank
         String content;
@@ -34,11 +34,11 @@ public class QuestionRequestDTO {
     public static class UpdateDTO {
         @ExistUser
         Long userId;
-        @NotBlank
+
         @Size(min = 1, max = 50)
         @NotBlank
         String title;
-        @NotBlank
+
         @Size(min = 1, max = 1500)
         @NotBlank
         String content;

--- a/src/main/java/qp/official/qp/web/dto/QuestionRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/QuestionRequestDTO.java
@@ -1,5 +1,6 @@
 package qp.official.qp.web.dto;
 
+import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 import qp.official.qp.validation.annotation.ExistHashTag;
 import qp.official.qp.validation.annotation.ExistUser;
@@ -14,8 +15,10 @@ public class QuestionRequestDTO {
         @ExistUser
         Long userId;
         @Size(min = 1, max = 50)
+        @NotBlank
         String title;
         @Size(min = 1, max = 1500)
+        @NotBlank
         String content;
 
         // size = 1, max = 10
@@ -29,8 +32,10 @@ public class QuestionRequestDTO {
         @ExistUser
         Long userId;
         @Size(min = 1, max = 50)
+        @NotBlank
         String title;
         @Size(min = 1, max = 1500)
+        @NotBlank
         String content;
     }
 }

--- a/src/main/java/qp/official/qp/web/dto/UserAuthDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserAuthDTO.java
@@ -8,19 +8,21 @@ public class UserAuthDTO {
 
     @Getter
     @Builder
-    @NotBlank
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserSignUpDTO {
+        @NotBlank
         String name;
+        @NotBlank
         String nickname;
+        @NotBlank
         String email;
+        @NotBlank
         String profileImage;
     }
 
     @Getter
     @Builder
-    @NotBlank
     @NoArgsConstructor
     @AllArgsConstructor
     public static class KaKaoUserInfoDTO {
@@ -32,7 +34,6 @@ public class UserAuthDTO {
 
     @Getter
     @Builder
-    @NotBlank
     @NoArgsConstructor
     @AllArgsConstructor
     public static class KaKaoAccountDTO {
@@ -40,17 +41,20 @@ public class UserAuthDTO {
         Boolean email_needs_agreement;
         Boolean is_email_valid;
         Boolean is_email_verified;
+        @NotBlank
         String email;
     }
 
     @Getter
     @Builder
-    @NotBlank
     @NoArgsConstructor
     @AllArgsConstructor
     public static class KaKaoPropertiesDTO{
+        @NotBlank
         String nickname;
+        @NotBlank
         String profile_image;
+        @NotBlank
         String thumbnail_image;
     }
 }

--- a/src/main/java/qp/official/qp/web/dto/UserAuthDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserAuthDTO.java
@@ -1,5 +1,6 @@
 package qp.official.qp.web.dto;
 
+import javax.validation.constraints.NotBlank;
 import lombok.*;
 
 
@@ -7,6 +8,7 @@ public class UserAuthDTO {
 
     @Getter
     @Builder
+    @NotBlank
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserSignUpDTO {
@@ -18,6 +20,7 @@ public class UserAuthDTO {
 
     @Getter
     @Builder
+    @NotBlank
     @NoArgsConstructor
     @AllArgsConstructor
     public static class KaKaoUserInfoDTO {
@@ -29,6 +32,7 @@ public class UserAuthDTO {
 
     @Getter
     @Builder
+    @NotBlank
     @NoArgsConstructor
     @AllArgsConstructor
     public static class KaKaoAccountDTO {
@@ -41,6 +45,7 @@ public class UserAuthDTO {
 
     @Getter
     @Builder
+    @NotBlank
     @NoArgsConstructor
     @AllArgsConstructor
     public static class KaKaoPropertiesDTO{

--- a/src/main/java/qp/official/qp/web/dto/UserRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserRequestDTO.java
@@ -1,6 +1,7 @@
 package qp.official.qp.web.dto;
 
 import lombok.*;
+import qp.official.qp.validation.annotation.ExistUser;
 
 
 public class UserRequestDTO {
@@ -18,6 +19,7 @@ public class UserRequestDTO {
      */
     @Getter
     public static class AutoLoginRequestDTO {
+        @ExistUser
         private Long userId;
     }
 


### PR DESCRIPTION
## PR type
- [x] Bug fix

## 💻 작업사항
- 작업사항 1 : 질문 신고, 해시태그, 이미지, 유저 입력 값 비어 있는 경우 500대 에러 발생 오류 수정

## ✔️ check list

- [X] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
