### PR TITLE
[refactor] 해시태그 및 유저 정보 수정 리팩토링

### DIFF
--- a/src/main/java/qp/official/qp/converter/UserConverter.java
+++ b/src/main/java/qp/official/qp/converter/UserConverter.java
@@ -21,7 +21,7 @@ public class UserConverter {
     public static UserResponseDTO.GetUserInfoDTO toUserGetInfoDTO(User user) {
         return UserResponseDTO.GetUserInfoDTO.builder()
                 .nickname(user.getNickname())
-                .profile_image(user.getProfileImage())
+                .profileImage(user.getProfileImage())
                 .email(user.getEmail())
                 .gender(user.getGender())
                 .point(user.getPoint())
@@ -32,7 +32,7 @@ public class UserConverter {
         return UserResponseDTO.UpdateUserInfoDTO.builder()
                 .userId(user.getUserId())
                 .nickname(user.getNickname())
-                .profile_image(user.getProfileImage())
+                .profileImage(user.getProfileImage())
                 .updatedAt(user.getUpdatedAt())
                 .build();
     }

--- a/src/main/java/qp/official/qp/service/HashtagService/HashtagQueryServiceImpl.java
+++ b/src/main/java/qp/official/qp/service/HashtagService/HashtagQueryServiceImpl.java
@@ -28,9 +28,11 @@ public class HashtagQueryServiceImpl implements HashtagQueryService {
 
         checkIsEmpty(request);
 
+        // 이미 존재 한다면, 그 해시태그 값을 리턴함.
         if (hashtagRepository.existsByHashtag(request.getHashtag())) {
-            throw new HashtagHandler(ErrorStatus.HASHTAG_ALREADY_EXISTS);
+            return hashtagRepository.findByHashtag(request.getHashtag());
         }
+
         Hashtag hashtag = HashtagConverter.toHashtag(request);
         return hashtagRepository.save(hashtag);
     }

--- a/src/main/java/qp/official/qp/service/UserService/UserServiceImpl.java
+++ b/src/main/java/qp/official/qp/service/UserService/UserServiceImpl.java
@@ -59,7 +59,7 @@ public class UserServiceImpl implements UserService {
     public User updateUserInfo(Long userId, UserRequestDTO.UpdateUserInfoRequestDTO requestDTO) {
         User user = userRepository.findById(userId).get();
         user.updateNickname(requestDTO.getNickname());
-        user.updateProfileImage(requestDTO.getProfile_image());
+        user.updateProfileImage(requestDTO.getProfileImage());
         return user;
     }
 

--- a/src/main/java/qp/official/qp/web/dto/UserRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserRequestDTO.java
@@ -14,7 +14,7 @@ public class UserRequestDTO {
     @Getter
     public static class UpdateUserInfoRequestDTO {
         private String nickname;
-        private String profile_image;
+        private String profileImage;
     }
     /**
      * 자동 로그인

--- a/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
@@ -45,7 +45,7 @@ public class UserResponseDTO {
     public static class GetUserInfoDTO {
         String name;
         String nickname;
-        String profile_image;
+        String profileImage;
         String email;
         Gender gender;
         Long point;
@@ -61,7 +61,7 @@ public class UserResponseDTO {
     public static class UpdateUserInfoDTO {
         Long userId;
         String nickname;
-        String profile_image;
+        String profileImage;
         LocalDateTime updatedAt;
     }
 


### PR DESCRIPTION
## PR type
- [x] Refactor

## 💻 작업사항

- 작업사항 1 : 해시태그 `POST` 생성 시 이미 존재한다면, 존재하는 해시태그 반환.
- 작업사항 2 : 유저 정보 수정 할때 프로필 이미지 필드 명 카멜 케이스로 수정.

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
