### PR TITLE
[fix] 유저 정보 수정 시 입력 되지 않은 값은 null로 수정되는 오류 해결

### DIFF
--- a/src/main/java/qp/official/qp/service/UserService/UserServiceImpl.java
+++ b/src/main/java/qp/official/qp/service/UserService/UserServiceImpl.java
@@ -58,8 +58,17 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public User updateUserInfo(Long userId, UserRequestDTO.UpdateUserInfoRequestDTO requestDTO) {
         User user = userRepository.findById(userId).get();
-        user.updateNickname(requestDTO.getNickname());
-        user.updateProfileImage(requestDTO.getProfile_image());
+
+        String updateNickname = requestDTO.getNickname();
+        String updateProfileImage = requestDTO.getProfile_image();
+
+        if (updateNickname != null && !updateNickname.isEmpty()){
+            user.updateNickname(requestDTO.getNickname());
+        }
+
+        if (updateProfileImage != null && !updateProfileImage.isEmpty()){
+            user.updateProfileImage(requestDTO.getProfile_image());
+        }
         return user;
     }
 

--- a/src/main/java/qp/official/qp/service/UserService/UserServiceImpl.java
+++ b/src/main/java/qp/official/qp/service/UserService/UserServiceImpl.java
@@ -60,14 +60,14 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findById(userId).get();
 
         String updateNickname = requestDTO.getNickname();
-        String updateProfileImage = requestDTO.getProfile_image();
+        String updateProfileImage = requestDTO.getProfileImage();
 
         if (updateNickname != null && !updateNickname.isEmpty()){
             user.updateNickname(requestDTO.getNickname());
         }
 
         if (updateProfileImage != null && !updateProfileImage.isEmpty()){
-            user.updateProfileImage(requestDTO.getProfile_image());
+            user.updateProfileImage(requestDTO.getProfileImage());
         }
 
         return user;


### PR DESCRIPTION
## PR type
- [x] Bug fix

## 💻 작업사항

- 작업사항 1 : 유저 정보 수정 시 입력 되지 않은 값은 null로 수정되는 오류 해결

1. 프로필 이미지만 입력 시
<img width="1482" alt="스크린샷 2024-02-08 오전 12 06 26" src="https://github.com/qp-official-org/QP_BACKEND/assets/77945998/8dc175d9-d772-4b34-a9e5-03ffe17ce50f">

--- 
2. 닉네임만 입력 시
<img width="1468" alt="스크린샷 2024-02-08 오전 12 06 48" src="https://github.com/qp-official-org/QP_BACKEND/assets/77945998/978f8cba-3ec8-41f3-b381-95f277111054">

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
