### PR TITLE
[fix] 유저 정보 조회시 name 필드가 null 로 조회되는 오류 해결

### DIFF
--- a/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
@@ -43,7 +43,6 @@ public class UserResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetUserInfoDTO {
-        String name;
         String nickname;
         String profileImage;
         String email;


### PR DESCRIPTION
## PR type
- [x] Bug fix

## 💻 작업사항

- 작업사항 1
유저 정보 조회시 name 필드가 null 로 조회되는 오류 해결

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
