### PR TITLE
[fix] User Delete API 호출시 updateAt null 로 반환되는 오류 해결

### DIFF
--- a/src/main/java/qp/official/qp/converter/UserConverter.java
+++ b/src/main/java/qp/official/qp/converter/UserConverter.java
@@ -37,10 +37,11 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.deleteUserDTO toUserDeleteDTO() {
+    public static UserResponseDTO.deleteUserDTO toUserDeleteDTO(User user) {
         return UserResponseDTO.deleteUserDTO.builder()
-                .userId(1L)
-                .status(UserStatus.DELETED)
+                .userId(user.getUserId())
+                .status(user.getStatus())
+                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/qp/official/qp/domain/User.java
+++ b/src/main/java/qp/official/qp/domain/User.java
@@ -84,4 +84,8 @@ public class User extends BaseEntity {
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
     }
+
+    public void updateStatus(UserStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/qp/official/qp/service/UserService/UserService.java
+++ b/src/main/java/qp/official/qp/service/UserService/UserService.java
@@ -11,5 +11,5 @@ public interface UserService {
     User createTestUser();
     User signUp(String code) throws IOException, ParseException;
     User autoSignIn(Long userId);
-
+    User deleteUser(Long userId);
 }

--- a/src/main/java/qp/official/qp/service/UserService/UserServiceImpl.java
+++ b/src/main/java/qp/official/qp/service/UserService/UserServiceImpl.java
@@ -2,13 +2,8 @@ package qp.official.qp.service.UserService;
 
 
 import com.google.gson.Gson;
-import java.io.BufferedWriter;
-import java.io.OutputStreamWriter;
-import java.text.ParseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.springframework.stereotype.Service;
 import qp.official.qp.apiPayload.code.status.ErrorStatus;
 import qp.official.qp.apiPayload.exception.handler.UserHandler;
@@ -16,6 +11,7 @@ import qp.official.qp.converter.UserConverter;
 import qp.official.qp.domain.User;
 import qp.official.qp.domain.enums.Gender;
 import qp.official.qp.domain.enums.Role;
+import qp.official.qp.domain.enums.UserStatus;
 import qp.official.qp.repository.UserRepository;
 import qp.official.qp.web.dto.UserAuthDTO.KaKaoUserInfoDTO;
 import qp.official.qp.web.dto.UserRequestDTO;
@@ -131,6 +127,14 @@ public class UserServiceImpl implements UserService {
         }
 
         return gson.fromJson(res.toString(), KaKaoUserInfoDTO.class);
+    }
+
+    @Override
+    public User deleteUser(Long userId){
+        User user = userRepository.findById(userId).get();
+        user.updateStatus(UserStatus.DELETED);
+        userRepository.save(user);
+        return user;
     }
 
 }

--- a/src/main/java/qp/official/qp/web/controller/UserRestController.java
+++ b/src/main/java/qp/official/qp/web/controller/UserRestController.java
@@ -105,12 +105,21 @@ public class UserRestController {
         );
     }
 
-    @PatchMapping("/delete")
-    @Operation(summary = "유저 삭제 API", description = "현재 로그인 한 유저의 상태가 DELETED로 변경됩니다.")
-    public ApiResponse<UserResponseDTO.deleteUserDTO> delete() {
+    @PatchMapping("/delete/{userId}")
+    @Operation(summary = "유저 삭제 API"
+            , description = "현재 로그인 한 유저의 상태가 DELETED로 변경됩니다."
+            , security = @SecurityRequirement(name = "accessToken")
+    )
+    public ApiResponse<UserResponseDTO.deleteUserDTO> delete(
+            @PathVariable @ExistUser Long userId
+    ) {
+        // accessToken으로 유효한 유저인지 인가
+        tokenService.isValidToken(userId);
+
+        User user = userService.deleteUser(userId);
         return ApiResponse.onSuccess(
                 SuccessStatus.User_OK,
-                UserConverter.toUserDeleteDTO()
+                UserConverter.toUserDeleteDTO(user)
         );
     }
 


### PR DESCRIPTION
## PR type
- [x] Bug fix

## 💻 작업사항

- 작업사항 1
User Delete API 호출시 updateAt null 로 반환되는 오류 해결

## 💡 작성한 이슈 외에 작업한 사항

- 작업사항 1
User Delete API 호출 시 삭제하고자하는 유저의 status가 DELETED로 수정되도록 구현

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
