### PR TITLE
[refactor] answer title 없는거로 수정, answer에 user로 key만들어서 user 정보 넘겨주기 (Question 처럼) 및 parentsAnswer 조회시 자식 답변의 갯수도 같이 반환하게끔 수정

### DIFF
--- a/src/main/java/qp/official/qp/converter/AnswerConverter.java
+++ b/src/main/java/qp/official/qp/converter/AnswerConverter.java
@@ -16,7 +16,6 @@ public class AnswerConverter {
 
     public static Answer toAnswer(AnswerRequestDTO.AnswerCreateDTO request){
         return Answer.builder()
-                .title(request.getTitle())
                 .content(request.getContent())
                 .category(request.getCategory())
                 .answerGroup(request.getAnswerGroup())
@@ -52,16 +51,13 @@ public class AnswerConverter {
         List<ParentAnswerPreviewDTO> parentAnswerPreviewDTOList = parentAnswerList.getContent()
             .stream()
             .map(answer -> new ParentAnswerPreviewDTO(
+                UserConverter.toUserPreviewWithAnswerDTO(answer.getUser()),
                 answer.getAnswerId(),
-                answer.getUser().getUserId(),
-                answer.getUser().getNickname(),
-                answer.getUser().getRole(),
-                answer.getUser().getProfileImage(),
-                answer.getTitle(),
                 answer.getContent(),
                 answer.getCategory(),
                 answer.getAnswerGroup(),
-                answer.getAnswerLikesList().size()
+                answer.getAnswerLikesList().size(),
+                answer.getChildren().size()
             ))
             .collect(Collectors.toList());
         return parentAnswerPreviewDTOList;
@@ -83,12 +79,8 @@ public class AnswerConverter {
     private static List<ChildAnswerPreviewDTO> getChildAnswerPreviewDTOS(Page<Answer> childAnswerList) {
         List<ChildAnswerPreviewDTO> childAnswerDTOList = childAnswerList.getContent().stream()
             .map(answer -> new ChildAnswerPreviewDTO(
+                UserConverter.toUserPreviewWithAnswerDTO(answer.getUser()),
                 answer.getAnswerId(),
-                answer.getUser().getUserId(),
-                answer.getUser().getNickname(),
-                answer.getUser().getRole(),
-                answer.getUser().getProfileImage(),
-                answer.getTitle(),
                 answer.getContent(),
                 answer.getCategory(),
                 answer.getAnswerGroup(),
@@ -102,7 +94,6 @@ public class AnswerConverter {
     public static AnswerResponseDTO.UpdateResultDTO toUpdateResultDTO(Answer answer) {
         return AnswerResponseDTO.UpdateResultDTO.builder()
                 .answerId(answer.getAnswerId())
-                .title(answer.getTitle())
                 .content(answer.getContent())
                 .updatedAt(answer.getUpdatedAt())
                 .build();

--- a/src/main/java/qp/official/qp/converter/UserConverter.java
+++ b/src/main/java/qp/official/qp/converter/UserConverter.java
@@ -50,7 +50,7 @@ public class UserConverter {
     public static UserResponseDTO.UserPreviewInQuestionDTO toUserPreviewWithQuestionDTO(User user) {
         return UserResponseDTO.UserPreviewInQuestionDTO.builder()
                 .userId(user.getUserId())
-                .ROLE(user.getRole())
+                .role(user.getRole())
                 .profileImage(user.getProfileImage())
                 .build();
     }
@@ -59,7 +59,7 @@ public class UserConverter {
         return UserResponseDTO.UserPreviewInAnswerDTO.builder()
                 .userId(user.getUserId())
                 .nickname(user.getNickname())
-                .ROLE(user.getRole())
+                .role(user.getRole())
                 .profileImage(user.getProfileImage())
                 .build();
     }

--- a/src/main/java/qp/official/qp/converter/UserConverter.java
+++ b/src/main/java/qp/official/qp/converter/UserConverter.java
@@ -55,6 +55,15 @@ public class UserConverter {
                 .build();
     }
 
+    public static UserResponseDTO.UserPreviewInAnswerDTO toUserPreviewWithAnswerDTO(User user) {
+        return UserResponseDTO.UserPreviewInAnswerDTO.builder()
+                .userId(user.getUserId())
+                .nickname(user.getNickname())
+                .ROLE(user.getRole())
+                .profileImage(user.getProfileImage())
+                .build();
+    }
+
     public static UserResponseDTO.UserSignUpResultDTO toUserSignUpResultDTO(TokenResponseDTO response, User user) {
         return UserResponseDTO.UserSignUpResultDTO.builder()
                 .userId(user.getUserId())

--- a/src/main/java/qp/official/qp/domain/Answer.java
+++ b/src/main/java/qp/official/qp/domain/Answer.java
@@ -28,9 +28,6 @@ public class Answer extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long answerId;
 
-    @Column(nullable = false, length = 50)
-    private String title;
-
     @Column(columnDefinition = "TEXT")
     private String content;
 
@@ -108,7 +105,6 @@ public class Answer extends BaseEntity {
 
 
     public void update(AnswerRequestDTO.AnswerUpdateDTO request) {
-        this.title = request.getTitle();
         this.content = request.getContent();
     }
 }

--- a/src/main/java/qp/official/qp/web/dto/AnswerRequestDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/AnswerRequestDTO.java
@@ -20,8 +20,6 @@ public class AnswerRequestDTO {
         @ExistUser
         Long userId;
         @NotBlank
-        String title;
-        @NotBlank
         String content;
         @NotNull(message = "카테고리는 'PARENT', 'CHILD' 중 하나여야 합니다.")
         Category category;
@@ -35,8 +33,6 @@ public class AnswerRequestDTO {
     public static class AnswerUpdateDTO {
         @ExistUser
         Long userId;
-        @NotBlank
-        String title;
         @NotBlank
         String content;
     }

--- a/src/main/java/qp/official/qp/web/dto/AnswerResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/AnswerResponseDTO.java
@@ -39,16 +39,13 @@ public class AnswerResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ParentAnswerPreviewDTO {
+        UserResponseDTO.UserPreviewInAnswerDTO user;
         Long answerId;
-        Long userId;
-        String nickname;
-        Role role;
-        String profileImage;
-        String title;
         String content;
         Category category;
         Long answerGroup;
         Integer likeCount;
+        Integer childAnswerCount;
     }
 
     @Builder
@@ -69,12 +66,8 @@ public class AnswerResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ChildAnswerPreviewDTO {
+        UserResponseDTO.UserPreviewInAnswerDTO user;
         Long answerId;
-        Long userId;
-        String nickname;
-        Role role;
-        String profileImage;
-        String title;
         String content;
         Category category;
         Long answerGroup;
@@ -87,7 +80,6 @@ public class AnswerResponseDTO {
     @AllArgsConstructor
     public static class UpdateResultDTO {
         Long answerId;
-        String title;
         String content;
         Long likeCount;
         LocalDateTime updatedAt;

--- a/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
@@ -88,7 +88,7 @@ public class UserResponseDTO {
     public static class UserPreviewInQuestionDTO {
         Long userId;
         String profileImage;
-        Role ROLE;
+        Role role;
     }
 
     @Builder
@@ -99,7 +99,7 @@ public class UserResponseDTO {
         Long userId;
         String nickname;
         String profileImage;
-        Role ROLE;
+        Role role;
     }
 
     @Builder

--- a/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
+++ b/src/main/java/qp/official/qp/web/dto/UserResponseDTO.java
@@ -95,6 +95,17 @@ public class UserResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class UserPreviewInAnswerDTO {
+        Long userId;
+        String nickname;
+        String profileImage;
+        Role ROLE;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class UpdateUserPointDTO {
         Long userId;
         Long point;

--- a/src/test/java/qp/official/qp/repository/AnswerLikesRepositoryTest.java
+++ b/src/test/java/qp/official/qp/repository/AnswerLikesRepositoryTest.java
@@ -33,7 +33,7 @@ class AnswerLikesRepositoryTest {
 
     void setUp(){
         answer = Answer.builder()
-            .title("testTitle")
+            .content("testContent")
             .build();
 
         answerRepository.save(answer);

--- a/src/test/java/qp/official/qp/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qp/official/qp/repository/AnswerRepositoryTest.java
@@ -77,11 +77,9 @@ public class AnswerRepositoryTest {
         questionRepository.save(testQuestion);
 
         //ParentAnswer
-        String parentAnswerTitle = "testParentAnswerTitle";
         String parentAnswerContent = "testParnetAnswerContent";
         Category parentAnswerCategory = Category.PARENT;
         testParentAnswer = Answer.builder()
-                .title(parentAnswerTitle)
                 .content(parentAnswerContent)
                 .category(parentAnswerCategory)
                 .children(new ArrayList<>())
@@ -106,7 +104,6 @@ public class AnswerRepositoryTest {
         // then------------------------------------------------------------------------------------------
         //Answer
         assertThat(saveAnswer).isNotNull();
-        assertThat(saveAnswer.getTitle().equals(testParentAnswer.getTitle()));
         assertThat(saveAnswer.getContent().equals(testParentAnswer.getContent()));
         assertThat(saveAnswer.getUser().equals(testParentAnswer.getUser()));
         assertThat(saveAnswer.getUser().equals(testParentAnswer.getQuestion()));
@@ -126,7 +123,6 @@ public class AnswerRepositoryTest {
         // then------------------------------------------------------------------------------------------
         //Answer
         assertEquals(1, allAnswer.size());
-        assertEquals(testParentAnswer.getTitle(), allAnswer.stream().findAny().get().getTitle());
         assertEquals(testParentAnswer.getContent(), allAnswer.stream().findAny().get().getContent());
         assertEquals(newUser, allAnswer.stream().findAny().get().getUser());
         assertEquals(testQuestion, allAnswer.stream().findAny().get().getQuestion());
@@ -138,11 +134,9 @@ public class AnswerRepositoryTest {
         // given-----------------------------------------------------------------------------------------
         //Question
         answerRepository.save(testParentAnswer);
-        String parentAnswerTitle2 = "testParentAnswerTitle2";
         String parentAnswerContent2 = "testParnetAnswerContent2";
         Category parentAnswerCategory = Category.PARENT;
         Answer testParentAnswer2 = Answer.builder()
-                .title(parentAnswerTitle2)
                 .content(parentAnswerContent2)
                 .category(parentAnswerCategory)
                 .children(new ArrayList<>())
@@ -175,11 +169,9 @@ public class AnswerRepositoryTest {
         // given-----------------------------------------------------------------------------------------
         answerRepository.save(testParentAnswer);
         //ChildAnswer
-        String childnswerTitle = "testChildAnswerTitle";
         String childAnswerContent = "testChildAnswerContent";
         Category childAnswerCategory = Category.CHILD;
         Answer testChildAnswer = Answer.builder()
-                .title(childnswerTitle)
                 .content(childAnswerContent)
                 .category(childAnswerCategory)
                 .children(new ArrayList<>())
@@ -194,7 +186,6 @@ public class AnswerRepositoryTest {
         String childAnswerContent2 = "testChildAnswerContent2";
         Category childAnswerCategory2 = Category.CHILD;
         Answer testChildAnswer2 = Answer.builder()
-                .title(childnswerTitle2)
                 .content(childAnswerContent2)
                 .category(childAnswerCategory2)
                 .children(new ArrayList<>())
@@ -232,10 +223,8 @@ public class AnswerRepositoryTest {
 
         // when------------------------------------------------------------------------------------------
         // testParentAnswer 수정
-        String updateTitle = "updateTestTitle";
         String updateContent = "updateTestContent";
         AnswerRequestDTO.AnswerUpdateDTO request = AnswerRequestDTO.AnswerUpdateDTO.builder() // UpdateDTO에 builder annotation생성
-                .title(updateTitle)
                 .content(updateContent)
                 .build();
 
@@ -245,7 +234,6 @@ public class AnswerRepositoryTest {
         //Answer
         List<Answer> allAnswer = answerRepository.findAll();
         assertEquals(1, allAnswer.size());
-        assertEquals(updateTitle, allAnswer.stream().findAny().get().getTitle());
         assertEquals(updateContent, allAnswer.stream().findAny().get().getContent());
     }
 
@@ -255,11 +243,9 @@ public class AnswerRepositoryTest {
         // given-----------------------------------------------------------------------------------------
         // static testParentAnswer 사용
         //ChildAnswer
-        String childnswerTitle = "testChildAnswerTitle";
         String childAnswerContent = "testChildAnswerContent";
         Category childAnswerCategory = Category.CHILD;
         Answer testChildAnswer = Answer.builder()
-                .title(childnswerTitle)
                 .content(childAnswerContent)
                 .category(childAnswerCategory)
                 .children(new ArrayList<>())

--- a/src/test/java/qp/official/qp/service/AnswerService/AnswerCommandServiceImplTest.java
+++ b/src/test/java/qp/official/qp/service/AnswerService/AnswerCommandServiceImplTest.java
@@ -51,7 +51,6 @@ class AnswerCommandServiceImplTest {
         String questionTitle = "questionTestTitle";
 
         // 답변 정보
-        String title = "testTitle";
         String content = "testContent";
         Category category = Category.PARENT;
 
@@ -60,7 +59,6 @@ class AnswerCommandServiceImplTest {
         // 예상 되는 답변 객체 생성
         Answer expectAnswer = Answer.builder()
             .answerId(answerId)
-            .title(title)
             .content(content)
             .category(category)
             .children(new ArrayList<>())
@@ -98,7 +96,6 @@ class AnswerCommandServiceImplTest {
         // when
         AnswerRequestDTO.AnswerCreateDTO request = AnswerRequestDTO.AnswerCreateDTO.builder()
             .userId(userId)
-            .title(title)
             .content(content)
             .category(category)
             .build();
@@ -115,7 +112,6 @@ class AnswerCommandServiceImplTest {
         for (int i = 0; i < childAnswerSize; i++){
             AnswerRequestDTO.AnswerCreateDTO childRequest = AnswerRequestDTO.AnswerCreateDTO.builder()
                 .userId(userId)
-                .title("testTitle" + i)
                 .content("testContent" + i)
                 .category(child)
                 .answerGroup(answerId)
@@ -127,7 +123,6 @@ class AnswerCommandServiceImplTest {
 
         // 검증
         assertEquals(answerId, answer.getAnswerId());
-        assertEquals(title, answer.getTitle());
         assertEquals(content, answer.getContent());
         assertEquals(category, answer.getCategory());
 
@@ -155,13 +150,13 @@ class AnswerCommandServiceImplTest {
         Long userId = 1L;
 
         // 답변 정보
-        String title = "testTitle";
+        String content = "testContent";
         Long answerId = 1L;
 
         // 예상 답변 객체 생성
         Answer expectAnswer = Answer.builder()
             .answerId(answerId)
-            .title(title)
+            .content(content)
             .build();
 
         // 테스트 사용자 객체 생성
@@ -210,13 +205,13 @@ class AnswerCommandServiceImplTest {
         Long userId = 1L;
 
         // 답변 정보
-        String title = "testTitle";
+        String content = "testContent";
         Long answerId = 1L;
 
         // 예상 답변 객체 생성
         Answer expectAnswer = Answer.builder()
             .answerId(answerId)
-            .title(title)
+            .content(content)
             .build();
 
         // 테스트 사용자 객체 생성
@@ -250,13 +245,13 @@ class AnswerCommandServiceImplTest {
         // given
 
         // 답변 정보
-        String title = "testTitle";
+        String content = "testContent";
         Long answerId = 1L;
 
         // 예상 답변 객체 생성
         Answer expectAnswer = Answer.builder()
             .answerId(answerId)
-            .title(title)
+            .content(content)
             .build();
 
         // answerRepository.findById
@@ -278,24 +273,20 @@ class AnswerCommandServiceImplTest {
         Long userId = 1L;
 
         // 업데이트 전 답변 정보
-        String originalTitle = "Original Title";
         String originalContent = "Original Content";
 
         // 업데이트 요청 정보
-        String updatedTitle = "Updated Title";
         String updatedContent = "Updated Content";
 
         // 기존 답변 객체 생성
         Answer originalAnswer = Answer.builder()
             .answerId(answerId)
-            .title(originalTitle)
             .content(originalContent)
             .build();
 
         // 답변 업데이트 DTO 생성
         AnswerRequestDTO.AnswerUpdateDTO request = AnswerRequestDTO.AnswerUpdateDTO.builder()
             .userId(userId)
-            .title(updatedTitle)
             .content(updatedContent)
             .build();
 
@@ -309,7 +300,6 @@ class AnswerCommandServiceImplTest {
         // then
         // answer 업데이트 확인
         assertEquals(answerId, updatedAnswer.getAnswerId());
-        assertEquals(updatedTitle, updatedAnswer.getTitle());
         assertEquals(updatedContent, updatedAnswer.getContent());
     }
 }

--- a/src/test/java/qp/official/qp/service/AnswerService/AnswerQueryServiceImplTest.java
+++ b/src/test/java/qp/official/qp/service/AnswerService/AnswerQueryServiceImplTest.java
@@ -53,7 +53,7 @@ class AnswerQueryServiceImplTest {
         for (int i = 1; i <= expectedAnswerListSize; i++) {
             expectedAnswerList.add(Answer.builder()
                 .answerId((long) i)
-                .title("Test" + i)
+                .content("Test" + i)
                 .build());
         }
 
@@ -92,11 +92,12 @@ class AnswerQueryServiceImplTest {
         int size = 10;
 
         String questionTitle = "test";
+        String answerContent = "testAnswerContent";
 
-        // 질문 객체 생성
+        // 부모답변 객체 생성
         Answer parentAnswer = Answer.builder()
             .answerId(parentAnswerId)
-            .title(questionTitle)
+            .content(answerContent)
             .children(new ArrayList<>())
             .build();
 
@@ -108,7 +109,7 @@ class AnswerQueryServiceImplTest {
         for (int i = 1; i <= expectedChildAnswerListSize; i++) {
             parentAnswerList.add(Answer.builder()
                 .answerId((long) i)
-                .title("Test" + i)
+                .content("Test" + i)
                 .category(Category.CHILD)
                 .parent(parentAnswer)
                 .answerGroup(parentAnswerId)


### PR DESCRIPTION
## PR type
- [x] Refactor

## 💻 작업사항

- 작업사항 1
answer title 없는거로 수정
- 작업사항 2
answer에 user로 key만들어서 user 정보 넘겨주기 (Question 처럼)
- 작업사항 3
parentsAnswer 조회시 자식 답변의 갯수도 같이 반환하게끔 수정

## 💡 작성한 이슈 외에 작업한 사항

- 작업사항 1
Answer Entity의 title column 삭제

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
