### PR TITLE
[feat] 알림 설정해도 질문 삭제 가능하게 수정

### DIFF
--- a/src/main/java/qp/official/qp/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/qp/official/qp/apiPayload/code/status/ErrorStatus.java
@@ -32,6 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
     QUESTION_ALARM_ALREADY_EXISTS(HttpStatus.CONFLICT, "QUESTION_2004", "해당 질문에 대한 알람 설정이 이미 존재 하는 유저 입니다."),
     QUESTION_ALARM_NOT_FOUND_BY_USER(HttpStatus.NOT_FOUND, "QUESTION_2005", "해당 유저가 설정한 알람은 존재 하지 않습니다."),
     QUESTION_NOT_EXIST_BY_USER(HttpStatus.NOT_FOUND, "QUESTION_2006", "해당 유저가 작성한 질문은 존재 하지 않습니다."),
+    QUESTION_NOT_MATCH_BY_USER(HttpStatus.BAD_REQUEST, "QUESTION_2007", "질문을 작성한 유저 본인만 삭제할 수 있습니다."),
 
     // 답변 관련 에러 3000
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "ANSWER_3001", "찾고있는 답변이 없습니다."),

--- a/src/main/java/qp/official/qp/domain/Question.java
+++ b/src/main/java/qp/official/qp/domain/Question.java
@@ -7,6 +7,7 @@ import qp.official.qp.domain.common.BaseEntity;
 import qp.official.qp.domain.enums.ChildStatus;
 import qp.official.qp.domain.enums.Role;
 import qp.official.qp.domain.mapping.QuestionHashTag;
+import qp.official.qp.domain.mapping.UserQuestionAlarm;
 import qp.official.qp.web.dto.QuestionRequestDTO;
 
 import javax.persistence.*;
@@ -51,6 +52,10 @@ public class Question extends BaseEntity {
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Answer> answers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<UserQuestionAlarm> alarms = new ArrayList<>();
 
     public Question addHit() {
         this.hit++;

--- a/src/main/java/qp/official/qp/service/QuestionService/QuestionCommandService.java
+++ b/src/main/java/qp/official/qp/service/QuestionService/QuestionCommandService.java
@@ -9,7 +9,7 @@ public interface QuestionCommandService {
 
     Question updateQuestion(Long questionId, QuestionRequestDTO.UpdateDTO request);
 
-    void deleteQuestion(Long questionId);
+    void deleteQuestion(Long questionId, Long userId);
 
     UserQuestionAlarm saveQuestionAlarm(Long questionId, Long userId);
 }

--- a/src/main/java/qp/official/qp/service/QuestionService/QuestionCommandServiceImpl.java
+++ b/src/main/java/qp/official/qp/service/QuestionService/QuestionCommandServiceImpl.java
@@ -66,8 +66,11 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
     }
 
     @Override
-    public void deleteQuestion(Long questionId) {
+    public void deleteQuestion(Long questionId, Long userId) {
         Question deleteQuestion = questionRepository.findById(questionId).get();
+        if (!deleteQuestion.getUser().getUserId().equals(userId)){
+            throw new QuestionHandler(ErrorStatus.QUESTION_NOT_MATCH_BY_USER);
+        }
         questionRepository.delete(deleteQuestion);
     }
 

--- a/src/main/java/qp/official/qp/web/controller/QuestionController.java
+++ b/src/main/java/qp/official/qp/web/controller/QuestionController.java
@@ -129,7 +129,7 @@ public class QuestionController {
         // accessToken으로 유효한 유저인지 인가
         tokenService.isValidToken(userId);
 
-        questionCommandService.deleteQuestion(questionId);
+        questionCommandService.deleteQuestion(questionId,userId);
         return ApiResponse.onSuccess(
                 SuccessStatus.Question_OK,
                 null

--- a/src/test/java/qp/official/qp/service/QuestionService/QuestionCommandServiceTest.java
+++ b/src/test/java/qp/official/qp/service/QuestionService/QuestionCommandServiceTest.java
@@ -164,10 +164,13 @@ class QuestionCommandServiceTest {
         String title = "testTitle";
         String content = "testContent";
 
+        User testUser = User.builder().userId(userId).build();
+
         //예상 질문 객체 생성
         // given
         Question expectQuestion = Question.builder()
                 .questionId(questionId)
+                .user(testUser)
                 .title(title)
                 .content(content)
                 .questionHashTagList(new ArrayList<>())

--- a/src/test/java/qp/official/qp/service/QuestionService/QuestionCommandServiceTest.java
+++ b/src/test/java/qp/official/qp/service/QuestionService/QuestionCommandServiceTest.java
@@ -175,7 +175,7 @@ class QuestionCommandServiceTest {
         when(questionRepository.findById(questionId)).thenReturn(Optional.of(expectQuestion));
 
         //질문 삭제
-        questionCommandService.deleteQuestion(questionId);
+        questionCommandService.deleteQuestion(questionId, 0L);
 
         //verify
         verify(questionRepository).delete(expectQuestion);

--- a/src/test/java/qp/official/qp/service/QuestionService/QuestionCommandServiceTest.java
+++ b/src/test/java/qp/official/qp/service/QuestionService/QuestionCommandServiceTest.java
@@ -160,6 +160,7 @@ class QuestionCommandServiceTest {
         // when
         // 질문 정보
         Long questionId = 1L;
+        Long userId = 2L;
         String title = "testTitle";
         String content = "testContent";
 
@@ -175,7 +176,7 @@ class QuestionCommandServiceTest {
         when(questionRepository.findById(questionId)).thenReturn(Optional.of(expectQuestion));
 
         //질문 삭제
-        questionCommandService.deleteQuestion(questionId, 0L);
+        questionCommandService.deleteQuestion(questionId, userId);
 
         //verify
         verify(questionRepository).delete(expectQuestion);


### PR DESCRIPTION
## PR type
- [x] Feature
- [x] Refactor

## 💻 작업사항

- 작업사항 1 : 알림 설정한 질문 삭제 시 발생하던 에러 수정 -> `Question` 엔티티에 
`private List<UserQuestionAlarm> alarms = new ArrayList<>();` 추가
- 작업사항 2 : 질문 작성한 본인만 질문 삭제 할 수 있도록 수정

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
